### PR TITLE
Use molecule for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,14 @@
----
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker-py molecule
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,40 @@
+---
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: postgresql-94-localhost
+    - name: postgresql-94-all
+
+docker:
+  containers:
+  - name: postgresql-94-localhost
+    image: centos/systemd
+    image_version: latest
+    privileged: True
+  - name: postgresql-94-all
+    image: centos/systemd
+    image_version: latest
+    privileged: True
+
+ansible:
+  host_vars:
+    postgresql-94-all:
+    - postgresql_server_listen: "'*'"
+      postgresql_server_auth:
+      - database: publicdb
+        user: alice
+        address: 192.168.1.0/24
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-postgresql
+      postgresql_users_databases:
+      - user: alice
+        password: alice123
+        databases: [publicdb, secretdb]
+      - user: bob
+        password: bob123
+        databases: [publicdb]
+        roles: "CREATEDB,NOSUPERUSER"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-postgresql

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,48 @@
+import testinfra.utils.ansible_runner
+import pytest
+from re import match
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+@pytest.mark.parametrize("name,expected_db", [
+    ('publicdb', 'publicdb|en_US.UTF-8|en_US.UTF-8'),
+    ('secretdb', 'secretdb|en_US.UTF-8|en_US.UTF-8')
+])
+def test_databases(Sudo, Command, name, expected_db):
+    sql = ("SELECT datname,datcollate,datctype FROM pg_database "
+           "WHERE datname='%s'" % name)
+    with Sudo('postgres'):
+        out = Command.check_output('psql postgres -c "%s" -At' % sql)
+    assert out == expected_db
+
+
+@pytest.mark.parametrize("name,expected_roles", [
+    ('alice', 'alice|f|t|f|f|f|t|f|-1|********|||'),
+    ('bob', 'bob|f|t|f|t|f|t|f|-1|********|||'),
+])
+def test_user_roles(Sudo, Command, name, expected_roles):
+    sql = "SELECT * FROM pg_roles WHERE rolname='%s'" % name
+    with Sudo('postgres'):
+        out = Command.check_output('psql postgres -c "%s" -At' % sql)
+    # Everything except the UID at the end
+    assert out.startswith(expected_roles)
+
+
+def test_server_listen(File, Sudo, TestinfraBackend):
+    host = TestinfraBackend.get_hostname()
+    with Sudo():
+        f = File('/var/lib/pgsql/9.4/data/postgresql.conf').content_string
+
+    count_listen_addresses = 0
+    for line in f.split('\n'):
+        if match('\s*listen_addresses', line):
+            count_listen_addresses += 1
+            listen_addresses = line
+    assert count_listen_addresses == 1
+
+    if host == 'postgresql-94-all':
+        assert listen_addresses == "listen_addresses = '\*'"
+    else:
+        assert listen_addresses == "listen_addresses = localhost"

--- a/tests/test_postgresql-94-all.py
+++ b/tests/test_postgresql-94-all.py
@@ -1,0 +1,10 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('postgresql-94-all')
+
+
+def test_server_hba(File, Sudo, TestinfraBackend):
+    with Sudo():
+        assert File('/var/lib/pgsql/9.4/data/pg_hba.conf').contains(
+            '^host publicdb alice 192.168.1.0/24 md5$')


### PR DESCRIPTION
Based on https://github.com/openmicroscopy/infrastructure/blob/2c628ad9660e85f0c8b8ec0192731955d9d77da2/ansible/test.yml#L40
Testing:
- `molecule test`
- `molecule test --driver vagrant`

Looks like travis isn't enabled on this repo.
