### PR TITLE
Clarifying initdb skip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 install:
-  - pip install ansible docker-py molecule==1.20
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Role Variables
 Defaults: `defaults/main.yml`
 
 - `postgresql_version`: The PostgreSQL version: `9.4` (default), `9.5`, `9.6`
-- `postgresql_install_server`: If True (default) install and initialise the server, otherwise only install the client
+- `postgresql_install_server`: If True (default) install and initialise the server (unless already installed and initialised), otherwise only install the client
 - `postgresql_users_databases`: List of dictionaries of users and databases to be created, ignored unless `postgresql_install_server` is `True`. Items should be of the form:
   - `user`: Database username
   - `password`: Database user password

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Defaults: `defaults/main.yml`
 
 - `postgresql_version`: The PostgreSQL version: `9.4` (default), `9.5`, `9.6`
 - `postgresql_install_server`: If True (default) install and initialise the server, otherwise only install the client
-- `postgresql_users_databases`: List of dictionaries of users and databases, ignored unless `postgresql_install_server` is `True`. Items should be of the form:
+- `postgresql_users_databases`: List of dictionaries of users and databases to be created, ignored unless `postgresql_install_server` is `True`. Items should be of the form:
   - `user`: Database username
   - `password`: Database user password
   - `databases`: [List of database names that user has access to]
@@ -30,6 +30,7 @@ Defaults: `defaults/main.yml`
 Example Playbook
 ----------------
 
+    # Install PostgreSQL, configure authenticaton, create users and databases.
     - hosts: localhost
       roles:
       - postgresql

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     state: directory
   when: postgresql_install_server and postgresql_server_chown_datadir
 
-- name: postgres | initialise data directory
+- name: postgres | initialise PostgreSQL cluster (skip if data directory already exists)
   become: yes
   command: "{{ postgresql_bindir }}/{{ postgresql_basename }}-setup initdb"
   args:


### PR DESCRIPTION
Possibly unnecessary, but other roles have more explanation in the example playbook.

I didn't realise that this role was creating the database - so just adding that clarification. Perhaps it's clear to others though.