### PR TITLE
README postgresql_server_listen example/usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   - `databases`: List of databases that user can connect to, required but can be empty `[]`
   - `roles`: Role attribute flags, optional
   If you want the user to have restricted access see the section below on Restricted users.
-- `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `"'*'"` for all
+- `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `'*'` for all
 - `postgresql_server_conf`: Dictionary of additional postgresql.conf options
 - `postgresql_server_auth_local`: Whether to allow the default postgres local authentication (default `True`)
 - `postgresql_server_auth`: List of dictionaries of authorisation parameters, if omitted the default local authentication only will be enabled. Items should be of the form:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   - `databases`: List of databases that user can connect to, required but can be empty `[]`
   - `roles`: Role attribute flags, optional
   If you want the user to have restricted access see the section below on Restricted users.
-- `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `'*'` for all
+- `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `"'*'"` for all
 - `postgresql_server_conf`: Dictionary of additional postgresql.conf options
 - `postgresql_server_auth_local`: Whether to allow the default postgres local authentication (default `True`)
 - `postgresql_server_auth`: List of dictionaries of authorisation parameters, if omitted the default local authentication only will be enabled. Items should be of the form:
@@ -59,7 +59,7 @@ Example Playbook
     - hosts: localhost
       roles:
       - role: postgresql
-        postgresql_server_listen: "'* '"
+        postgresql_server_listen: "'*'"
         postgresql_server_auth:
         - database: publicdb
           user: alice


### PR DESCRIPTION
 The current example in the usage of the variable `postgresql_server_listen`:
> use `'*'` for all

If you try this exact value, PostgreSQL fails to start. 

```
Sep 15 23:24:11 pg-int-testing.openmicroscopy.org postmaster[18973]: LOG:  syntax error in file "/var/lib/pgsql/9.6/data/postgresql.conf" line 644, near token "*"
Sep 15 23:24:11 pg-int-testing.openmicroscopy.org postmaster[18973]: FATAL:  configuration file "/var/lib/pgsql/9.6/data/postgresql.conf" contains errors
```

It needs to be quoted to work, which is in fact the syntax used below in the Example Playbook section, cf https://github.com/openmicroscopy/ansible-role-postgresql/blame/master/README.md#L62

It's correct that you want to end up with `'*'` in the `postgresql.conf` file, but since that's not the Ansible syntax to achieve it, perhaps it shouldn't be written that way in the variable usage?