### PR TITLE
Add ability to define collation, encoding and ctype for each database

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   Items should be of the form:
   - `name`: Database name
   - `owner`: Owner role (optional)
+  - `lc_collate`: Collation order (LC_COLLATE) to use in the database, default `en_US.UTF-8`
+  - `lc_ctype`: Character classification (LC_CTYPE) to use in the database, default `en_US.UTF-8`
+  - `encoding`: Encoding of the database, default `UTF-8`
+  - `template`: Template used to create the database, default `template0`
   - `restrict`: If `True` revoke default `PUBLIC` privileges from database and `public` schema, default `False`
 - `postgresql_users`: List of dictionaries of users.
   Items should be of the form:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   Items should be of the form:
   - `name`: Database name
   - `owner`: Owner role (optional)
-  - `lc_collate`: Collation order (LC_COLLATE) to use in the database, default `en_US.UTF-8`
-  - `lc_ctype`: Character classification (LC_CTYPE) to use in the database, default `en_US.UTF-8`
+  - `lc_collate`: Collation order (LC_COLLATE) to use in the database
+  - `lc_ctype`: Character classification (LC_CTYPE) to use in the database
   - `encoding`: Encoding of the database, default `UTF-8`
-  - `template`: Template used to create the database, default `template0`
+  - `template`: Template used to create the database
   - `restrict`: If `True` revoke default `PUBLIC` privileges from database and `public` schema, default `False`
 - `postgresql_users`: List of dictionaries of users.
   Items should be of the form:

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -36,10 +36,10 @@
     name: "{{ item.name }}"
     owner: "{{ item.owner | default(omit) }}"
     state: present
-    lc_collate: "{{ item.lc_collate | default('en_US.UTF-8') }}"
-    lc_ctype: "{{ item.lc_ctype | default('en_US.UTF-8') }}"
+    lc_collate: "{{ item.lc_collate | default(omit) }}"
+    lc_ctype: "{{ item.lc_ctype | default(omit) }}"
     encoding: "{{ item.encoding | default('UTF-8') }}"
-    template: "{{ item.template | default('template0') }}"
+    template: "{{ item.template | default(omit) }}"
   with_items:
     - "{{ postgresql_databases }}"
 

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -33,10 +33,13 @@
   become: true
   become_user: postgres
   postgresql_db:
-    encoding: UTF-8
     name: "{{ item.name }}"
     owner: "{{ item.owner | default(omit) }}"
     state: present
+    lc_collate: "{{ item.lc_collate | default('en_US.UTF-8') }}"
+    lc_ctype: "{{ item.lc_ctype | default('en_US.UTF-8') }}"
+    encoding: "{{ item.encoding | default('UTF-8') }}"
+    template: "{{ item.template | default('template0') }}"
   with_items:
     - "{{ postgresql_databases }}"
 


### PR DESCRIPTION
I added the ability to define collation, character type and encoding for each database. I don't know if you're happy with the defined defaults, since you haven't defined such for collation and character type.