### PR TITLE
Pin python2-psycopg2 package

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -29,8 +29,7 @@ platforms:
       - server
       - extra_options
   - name: postgresql-noserver
-    image: centos
-    image_version: 7
+    image: centos:7
   - name: postgresql-10-localhost
     image: centos/systemd
     image_version: latest

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -14,10 +14,10 @@
   yum:
     name: "{{ item }}"
     state: present
+    disablerepo: "*"
+    enablerepo: "{{ postgresql_repoid }}"
   with_items:
-    # TODO: unpin once a new package has been released fixing compatibility
-    # with all PSQL versions
-    - python2-psycopg2-2.8.3-1.rhel7.x86_64
+    - python2-psycopg2
 
 - name: postgres | create users
   become: true

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -15,7 +15,9 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - python-psycopg2
+    # TODO: unpin once a new package has been released fixing compatibility
+    # with all PSQL versions
+    - python2-psycopg2-2.8.3-1.rhel7.x86_64
 
 - name: postgres | create users
   become: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,11 @@
 # vars file for ome.postgresql
 
 postgresql_external:
+  repo:
+    "9.4": pgdg94
+    "9.5": pgdg95
+    "9.6": pgdg96
+    "10": pgdg10
   basename:
     "9.4": postgresql94
     "9.5": postgresql95
@@ -19,6 +24,7 @@ postgresql_datadir: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_basename: "{{ postgresql_external.basename[postgresql_version] }}"
 postgresql_repourl: "https://download.postgresql.org/pub/repos/yum/reporpms/\
   EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
+postgresql_repoid: "{{ postgresql_external.repo[postgresql_version] }}"
 postgresql_setupname: "{{ postgresql_external.setup[postgresql_version] }}"
 postgresql_version_suffix: >-
   {{

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,15 +2,6 @@
 # vars file for ome.postgresql
 
 postgresql_external:
-  repourl:
-    "9.4": "https://download.postgresql.org/pub/repos/yum/9.4/redhat/\
-      rhel-7-x86_64/pgdg-redhat94-9.4-3.noarch.rpm"
-    "9.5": "https://download.postgresql.org/pub/repos/yum/9.5/redhat/\
-      rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm"
-    "9.6": "https://download.postgresql.org/pub/repos/yum/9.6/redhat/\
-      rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm"
-    "10": "https://download.postgresql.org/pub/repos/yum/10/redhat/\
-      rhel-7-x86_64/pgdg-redhat10-10-2.noarch.rpm"
   basename:
     "9.4": postgresql94
     "9.5": postgresql95
@@ -26,7 +17,8 @@ postgresql_external:
 postgresql_bindir: /usr/pgsql-{{ postgresql_version }}/bin
 postgresql_datadir: /var/lib/pgsql/{{ postgresql_version }}/data
 postgresql_basename: "{{ postgresql_external.basename[postgresql_version] }}"
-postgresql_repourl: "{{ postgresql_external.repourl[postgresql_version] }}"
+postgresql_repourl: "https://download.postgresql.org/pub/repos/yum/reporpms/\
+  EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm"
 postgresql_setupname: "{{ postgresql_external.setup[postgresql_version] }}"
 postgresql_version_suffix: >-
   {{


### PR DESCRIPTION
See https://www.postgresql.org/message-id/EA7F5495-64AE-4BEF-81B1-7FA921BBE690%40gmail.com

The latest versions of `python2-psycopg2` pushed to the PostgreSQL YUM repo coupled with the obsolescence of `python-psycopg2` have broken compatibility with PSQL 9.4, 9.5 and 9.6. This PR
caps the version of psycopg2 installed to fix the `postgresql_user` module.

Additionally, this PR makes two changes:
- use `centos:7` as the `image` in `molecule.yml` since `centos:latest` is now `centos:8` and `image_version` is dropped in Molecule 2
- updates `vars/main.yml` to use the single RedHat Yum repository - see https://www.postgresql.org/message-id/6f1e601300d575195d4f0d8a066ef4abf4c90c99.camel@gunduz.org 

Given the impact on all playbooks both for fresh deployments and production deployments, proposing to get this released as an emergency 3.3.1 /cc @joshmoore @manics @jburel  