### PR TITLE
Set postgresql.conf permissions to 644

### DIFF
--- a/tasks/initialise.yml
+++ b/tasks/initialise.yml
@@ -32,7 +32,7 @@
     dest: >-
       {{ postgresql_dist[ansible_os_family | lower].confdir }}/postgresql.conf
     src: "{{ postgresql_dist[ansible_os_family | lower].conf_postgresql_src }}"
-    mode: 0640
+    mode: 0644
   notify:
     - restart postgresql
 


### PR DESCRIPTION
Fixes #23

See also https://github.com/sous-chefs/postgresql/issues/588 which was discussing a similar issue in a different environment and in particular the [best practices link](https://www.endpoint.com/blog/2010/09/27/postgres-configuration-best-practices) 

```
All the conf files should be owned by the postgres user, and the configuration files should be world-readable if possible (indeed, it’s a requirement for Debian based system that postgresql.conf be readable for psql to work!). 
```

The tests should remain green. Proposing to release as `5.0.3`