### PR TITLE
Changing multi-distro vars to facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Defaults: `defaults/main.yml`
 
 - `postgresql_version`: The PostgreSQL major version: `9.6`, `10`, `11`, `12`
 - `postgresql_package_version`: The PostgreSQL full version, leave this empty to use the latest minor release from `postgresql_version`, ignored on Ubuntu
+- `postgresql_dist_redhat` or `postgresql_dist_debian`: Object that define configuration attributes for PostgreSQL on each specific OS, these variables allow to change the interaction between variables defined at [ome.postgresql](https://galaxy.ansible.com/ome/postgresql) and [ome.postgresql_client](https://github.com/ome/ansible-role-postgresql-client)
 
 The following parameters will be ignored if `postgresql_install_server: False`:
 - `postgresql_databases`: List of dictionaries of databases.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@
 # Full package version of postgres, see ome.postgresql_client
 # postgresql_package_version
 
+# OS system user to become when become_user: <USER> is defined
+postgresql_become_user: postgres
+
 # List of dictionaries of databases
 postgresql_databases: []
 
@@ -28,32 +31,31 @@ postgresql_server_auth: []
 # Recursively reset the owner/group of the postgres datadir?
 postgresql_server_chown_datadir: false
 
-
 ######################################################################
 # Internal role variables, do not modify
 ######################################################################
 
 # Uses postgresql_distribution_redhat from ome.postgresql_client
-postgresql_dist:
-  redhat:
-    bindir: /usr/pgsql-{{ postgresql_version }}/bin
-    confdir: /var/lib/pgsql/{{ postgresql_version }}/data
-    conf_postgresql_src: postgresql-conf.j2
-    datadir: /var/lib/pgsql/{{ postgresql_version }}/data
-    basename: >-
-      {{ postgresql_distribution_redhat[postgresql_version].basename }}
-    repoid: "{{ postgresql_distribution_redhat[postgresql_version].repo }}"
-    setupname: "{{ postgresql_distribution_redhat[postgresql_version].setup }}"
-    service: postgresql-{{ postgresql_version }}
-    version_suffix: >-
-      {{
-        (postgresql_package_version | length > 0) |
-        ternary('-' + postgresql_package_version, '')
-      }}
-  debian:
-    bindir: /usr/lib/postgresql/{{ postgresql_version }}/bin
-    confdir: /etc/postgresql/{{ postgresql_version }}/main
-    conf_postgresql_src: postgresql-conf-10-ubuntu.j2
-    datadir: /var/lib/postgresql/{{ postgresql_version }}/main
-    basename: postgresql-{{ postgresql_version }}
-    service: postgresql
+postgresql_dist_redhat:
+  bindir: /usr/pgsql-{{ postgresql_version }}/bin
+  confdir: /var/lib/pgsql/{{ postgresql_version }}/data
+  conf_postgresql_src: postgresql-conf.j2
+  datadir: /var/lib/pgsql/{{ postgresql_version }}/data
+  basename: >-
+    {{ postgresql_distribution_redhat[postgresql_version].basename }}
+  repoid: "{{ postgresql_distribution_redhat[postgresql_version].repo }}"
+  setupname: "{{ postgresql_distribution_redhat[postgresql_version].setup }}"
+  service: postgresql-{{ postgresql_version }}
+  version_suffix: >-
+    {{
+      (postgresql_package_version | length > 0) |
+      ternary('-' + postgresql_package_version, '')
+    }}
+
+postgresql_dist_debian:
+  bindir: /usr/lib/postgresql/{{ postgresql_version }}/bin
+  confdir: /etc/postgresql/{{ postgresql_version }}/main
+  conf_postgresql_src: postgresql-conf-10-ubuntu.j2
+  datadir: /var/lib/postgresql/{{ postgresql_version }}/main
+  basename: postgresql-{{ postgresql_version }}
+  service: postgresql

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,11 @@ postgresql_server_chown_datadir: false
 # Internal role variables, do not modify
 ######################################################################
 
-# Uses postgresql_distribution_redhat from ome.postgresql_client
+# Attributes are parsed and used to set facts at tasks/redhat.yml.
+# Overriding the default values allow to configure future versions of
+# PostgreSQL, e.g. different paths according to the version, config, etc.
+# NOTE: Default values rely on variable postgresql_distribution_redhat, which is
+# by default set at ome.postgresql_client.
 postgresql_dist_redhat:
   bindir: /usr/pgsql-{{ postgresql_version }}/bin
   confdir: /var/lib/pgsql/{{ postgresql_version }}/data
@@ -52,6 +56,8 @@ postgresql_dist_redhat:
       ternary('-' + postgresql_package_version, '')
     }}
 
+# Attributes are parsed and used to set facts at tasks/debian.yml.
+# Debian variation, following the same principles of postgresql_dist_redhat
 postgresql_dist_debian:
   bindir: /usr/lib/postgresql/{{ postgresql_version }}/bin
   confdir: /etc/postgresql/{{ postgresql_version }}/main

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,5 +4,5 @@
 - name: restart postgresql
   become: true
   service:
-    name: "{{ postgresql_dist[ansible_os_family | lower].service }}"
+    name: "{{ postgresql_dist_service }}"
     state: restarted

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,122 +2,112 @@
 # Manage local databases and users
 # This only works where the local system `postgres` user has admin rights
 
-- name: postgres | create users
+- block:
+    - name: postgres | create users
+      postgresql_user:
+        encrypted: true
+        name: "{{ item.user }}"
+        password: "{{ item.password }}"
+        role_attr_flags: "{{ item.roles | default(omit) }}"
+        state: present
+      with_items:
+        - "{{ postgresql_users }}"
+
+    - name: postgres | create databases
+      postgresql_db:
+        name: "{{ item.name }}"
+        owner: "{{ item.owner | default(omit) }}"
+        state: present
+        lc_collate: "{{ item.lc_collate | default(omit) }}"
+        lc_ctype: "{{ item.lc_ctype | default(omit) }}"
+        encoding: "{{ item.encoding | default('UTF-8') }}"
+        template: "{{ item.template | default(omit) }}"
+      with_items:
+        - "{{ postgresql_databases }}"
+
+    # Setting privileges is complicated:
+    # - https://stackoverflow.com/a/39029296
+
+    # From https://www.postgresql.org/docs/9.6/static/sql-grant.html:
+    #
+    # "The key word PUBLIC indicates that the privileges are to be granted to all
+    # roles, including those that might be created later. PUBLIC can be thought of
+    # as an implicitly defined group that always includes all roles. Any
+    # particular role will have the sum of privileges granted directly to it,
+    # privileges granted to any role it is presently a member of, and privileges
+    # granted to PUBLIC."
+    #
+    # "There is no need to grant privileges to the owner of an object (usually
+    # the user that created it), as the owner has all privileges by default. (The
+    # owner could, however, choose to revoke some of their own privileges for
+    # safety.)"
+    #
+    # "PostgreSQL grants default privileges on some types of objects to PUBLIC.
+    # No privileges are granted to PUBLIC by default on tables, columns, schemas
+    # or tablespaces. For other types, the default privileges granted to PUBLIC
+    # are as follows: CONNECT and CREATE TEMP TABLE for databases; EXECUTE
+    # privilege for functions; and USAGE privilege for languages."
+
+    - name: postgres | revoke default permissions
+      postgresql_privs:
+        database: "{{ item.name }}"
+        privs: ALL
+        roles: PUBLIC
+        state: absent
+        type: database
+      when: "item.restrict | default(False)"
+      with_items:
+        - "{{ postgresql_databases }}"
+
+    # Revoke the default permissions on the public schema
+    - name: postgres | revoke default schema permissions
+      postgresql_privs:
+        database: "{{ item.name }}"
+        obj: public
+        privs: ALL
+        roles: PUBLIC
+        state: absent
+        type: schema
+      when: "item.restrict | default(False)"
+      with_items:
+        - "{{ postgresql_databases }}"
+
+    # The default public schema is owned by postgres, and since the PUBLIC
+    # privileges are revoked we must grant them back to the owner
+    - name: postgres | grant database owner public schema privileges
+      postgresql_privs:
+        database: "{{ item.name }}"
+        obj: public
+        privs: ALL
+        roles: "{{ item.owner }}"
+        state: present
+        type: schema
+      when: item.owner is defined
+      with_items:
+        - "{{ postgresql_databases }}"
+
+    - name: postgres | grant connect privileges
+      postgresql_privs:
+        database: "{{ item.1 }}"
+        privs: CONNECT
+        roles: "{{ item.0.user }}"
+        state: present
+        type: database
+      with_subelements:
+        - "{{ postgresql_users }}"
+        - databases
+
+    - name: postgres | grant usage privileges on default public schema
+      postgresql_privs:
+        database: "{{ item.1 }}"
+        objs: public
+        privs: USAGE
+        roles: "{{ item.0.user }}"
+        state: present
+        type: schema
+      with_subelements:
+        - "{{ postgresql_users }}"
+        - databases
+
   become: true
-  become_user: postgres
-  postgresql_user:
-    encrypted: true
-    name: "{{ item.user }}"
-    password: "{{ item.password }}"
-    role_attr_flags: "{{ item.roles | default(omit) }}"
-    state: present
-  with_items:
-    - "{{ postgresql_users }}"
-
-- name: postgres | create databases
-  become: true
-  become_user: postgres
-  postgresql_db:
-    name: "{{ item.name }}"
-    owner: "{{ item.owner | default(omit) }}"
-    state: present
-    lc_collate: "{{ item.lc_collate | default(omit) }}"
-    lc_ctype: "{{ item.lc_ctype | default(omit) }}"
-    encoding: "{{ item.encoding | default('UTF-8') }}"
-    template: "{{ item.template | default(omit) }}"
-  with_items:
-    - "{{ postgresql_databases }}"
-
-# Setting privileges is complicated:
-# - https://stackoverflow.com/a/39029296
-
-# From https://www.postgresql.org/docs/9.6/static/sql-grant.html:
-#
-# "The key word PUBLIC indicates that the privileges are to be granted to all
-# roles, including those that might be created later. PUBLIC can be thought of
-# as an implicitly defined group that always includes all roles. Any
-# particular role will have the sum of privileges granted directly to it,
-# privileges granted to any role it is presently a member of, and privileges
-# granted to PUBLIC."
-#
-# "There is no need to grant privileges to the owner of an object (usually
-# the user that created it), as the owner has all privileges by default. (The
-# owner could, however, choose to revoke some of their own privileges for
-# safety.)"
-#
-# "PostgreSQL grants default privileges on some types of objects to PUBLIC.
-# No privileges are granted to PUBLIC by default on tables, columns, schemas
-# or tablespaces. For other types, the default privileges granted to PUBLIC
-# are as follows: CONNECT and CREATE TEMP TABLE for databases; EXECUTE
-# privilege for functions; and USAGE privilege for languages."
-
-- name: postgres | revoke default permissions
-  become: true
-  become_user: postgres
-  postgresql_privs:
-    database: "{{ item.name }}"
-    privs: ALL
-    roles: PUBLIC
-    state: absent
-    type: database
-  when: "item.restrict | default(False)"
-  with_items:
-    - "{{ postgresql_databases }}"
-
-# Revoke the default permissions on the public schema
-- name: postgres | revoke default schema permissions
-  become: true
-  become_user: postgres
-  postgresql_privs:
-    database: "{{ item.name }}"
-    obj: public
-    privs: ALL
-    roles: PUBLIC
-    state: absent
-    type: schema
-  when: "item.restrict | default(False)"
-  with_items:
-    - "{{ postgresql_databases }}"
-
-# The default public schema is owned by postgres, and since the PUBLIC
-# privileges are revoked we must grant them back to the owner
-- name: postgres | grant database owner public schema privileges
-  become: true
-  become_user: postgres
-  postgresql_privs:
-    database: "{{ item.name }}"
-    obj: public
-    privs: ALL
-    roles: "{{ item.owner }}"
-    state: present
-    type: schema
-  when: item.owner is defined
-  with_items:
-    - "{{ postgresql_databases }}"
-
-- name: postgres | grant connect privileges
-  become: true
-  become_user: postgres
-  postgresql_privs:
-    database: "{{ item.1 }}"
-    privs: CONNECT
-    roles: "{{ item.0.user }}"
-    state: present
-    type: database
-  with_subelements:
-    - "{{ postgresql_users }}"
-    - databases
-
-- name: postgres | grant usage privileges on default public schema
-  become: true
-  become_user: postgres
-  postgresql_privs:
-    database: "{{ item.1 }}"
-    objs: public
-    privs: USAGE
-    roles: "{{ item.0.user }}"
-    state: present
-    type: schema
-  with_subelements:
-    - "{{ postgresql_users }}"
-    - databases
+  become_user: "{{ postgresql_become_user }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -30,17 +30,17 @@
 
     # From https://www.postgresql.org/docs/9.6/static/sql-grant.html:
     #
-    # "The key word PUBLIC indicates that the privileges are to be granted to all
-    # roles, including those that might be created later. PUBLIC can be thought of
-    # as an implicitly defined group that always includes all roles. Any
-    # particular role will have the sum of privileges granted directly to it,
-    # privileges granted to any role it is presently a member of, and privileges
-    # granted to PUBLIC."
+    # "The key word PUBLIC indicates that the privileges are to be granted to
+    # all roles, including those that might be created later. PUBLIC can be
+    # thought of as an implicitly defined group that always includes all roles.
+    # Any particular role will have the sum of privileges granted directly to
+    # it, privileges granted to any role it is presently a member of, and
+    # privileges granted to PUBLIC."
     #
     # "There is no need to grant privileges to the owner of an object (usually
-    # the user that created it), as the owner has all privileges by default. (The
-    # owner could, however, choose to revoke some of their own privileges for
-    # safety.)"
+    # the user that created it), as the owner has all privileges by default.
+    # (The owner could, however, choose to revoke some of their own privileges
+    # for safety.)"
     #
     # "PostgreSQL grants default privileges on some types of objects to PUBLIC.
     # No privileges are granted to PUBLIC by default on tables, columns, schemas

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -5,7 +5,7 @@
   become: true
   apt:
     name: >-
-      {{ postgresql_dist.debian.basename }}
+      {{ postgresql_dist_debian.basename }}
     state: present
 
 - name: postgres | install ansible prerequisites
@@ -17,3 +17,13 @@
         ansible_python_version is version('3.0.0', '<') | ternary('', '3')
       }}-psycopg2
     state: present
+
+- name: postgres | set debian dist variables
+  set_fact:
+    postgresql_dist_datadir: "{{ postgresql_dist_debian.datadir }}"
+    postgresql_dist_bindir: "{{ postgresql_dist_debian.bindir }}"
+    postgresql_dist_confdir: "{{ postgresql_dist_debian.confdir }}"
+    postgresql_dist_setup: "{{ postgresql_dist_debian.bindir }}/initdb"
+    postgresql_dist_service: "{{ postgresql_dist_debian.service }}"
+    postgresql_dist_conf_postgresql_src: >-
+      {{ postgresql_dist_debian.conf_postgresql_src }}

--- a/tasks/initialise.yml
+++ b/tasks/initialise.yml
@@ -1,54 +1,51 @@
 ---
 # tasks file for ome.postgresql
 
-- name: postgres | set permissions on data directory
-  become: true
-  file:
-    owner: postgres
-    group: postgres
-    path: "{{ postgresql_dist[ansible_os_family | lower].datadir }}"
-    state: directory
-    mode: 0700
-  when: postgresql_server_chown_datadir
+- block:
+    - name: postgres | set permissions on data directory
+      file:
+        owner: postgres
+        group: postgres
+        path: "{{ postgresql_dist_datadir }}"
+        state: directory
+        mode: 0700
+      when: postgresql_server_chown_datadir
 
-- name: >-
-    postgres | initialise PostgreSQL cluster (skip if data directory
-    already exists)
-  become: true
-  command: >-
-    {{ postgresql_dist[ansible_os_family | lower].bindir }}/{{
-       postgresql_dist.redhat.setupname }}
-    initdb
-  args:
-    creates: >-
-      {{ postgresql_dist[ansible_os_family | lower].datadir }}/PG_VERSION
-  environment:
-    PGSETUP_INITDB_OPTIONS: --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5
+    - name: >-
+        postgres | initialise PostgreSQL cluster (skip if data directory
+        already exists)
+      command: "{{ postgresql_dist_setup }}"
+      args:
+        creates: "{{ postgresql_dist_datadir }}/PG_VERSION"
 
-- name: postgres | postgresql config file
-  become: true
-  become_user: postgres
-  template:
-    dest: >-
-      {{ postgresql_dist[ansible_os_family | lower].confdir }}/postgresql.conf
-    src: "{{ postgresql_dist[ansible_os_family | lower].conf_postgresql_src }}"
-    mode: 0644
-  notify:
-    - restart postgresql
+      environment:
+        PGSETUP_INITDB_OPTIONS: --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5
 
-- name: postgres | configure client authorisation
-  become: true
-  become_user: postgres
-  template:
-    dest: "{{ postgresql_dist[ansible_os_family | lower].confdir }}/pg_hba.conf"
-    src: pg_hba-conf.j2
-    mode: 0640
-  notify:
-    - restart postgresql
+    - name: postgres | postgresql config file
+      template:
+        dest: >-
+          {{ postgresql_dist_confdir }}/postgresql.conf
+        src: "{{ postgresql_dist_conf_postgresql_src }}"
+        mode: 0644
+      notify:
+        - restart postgresql
 
-- name: postgres | start service
+      become_user: "{{ postgresql_become_user }}"
+
+    - name: postgres | configure client authorisation
+      template:
+        dest: "{{ postgresql_dist_confdir }}/pg_hba.conf"
+        src: pg_hba-conf.j2
+        mode: 0640
+      notify:
+        - restart postgresql
+
+      become_user: "{{ postgresql_become_user }}"
+
+    - name: postgres | start service
+      service:
+        enabled: true
+        name: "{{ postgresql_dist_service }}"
+        state: started
+
   become: true
-  service:
-    enabled: true
-    name: "{{ postgresql_dist[ansible_os_family | lower].service }}"
-    state: started

--- a/tasks/initialise.yml
+++ b/tasks/initialise.yml
@@ -19,7 +19,8 @@
         creates: "{{ postgresql_dist_datadir }}/PG_VERSION"
 
       environment:
-        PGSETUP_INITDB_OPTIONS: --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5
+        PGSETUP_INITDB_OPTIONS: >-
+          --encoding=UTF8 --locale=en_US.UTF-8 --auth-host=md5
 
     - name: postgres | postgresql config file
       template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,14 +6,14 @@
     msg: >
       Variable 'postgresql_users_databases' has been replaced by
       'postgresql_databases' and 'postgresql_users'
-  when: 'postgresql_users_databases | default(False)'
+  when: "postgresql_users_databases | default(False)"
 
 - name: postgres | fail if postgresql_install_server true
   fail:
     msg: >
       Variable 'postgresql_install_server=false' has been replaced by the
       'ome.postgresql_client' role
-  when: 'not (postgresql_install_server | default(True))'
+  when: "not (postgresql_install_server | default(True))"
 
 - import_tasks: redhat.yml
   when: ansible_os_family | lower == 'redhat'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,16 +5,16 @@
   become: true
   yum:
     name: >-
-      {{ postgresql_dist.redhat.basename }}-server{{
-         postgresql_dist.redhat.version_suffix }}
+      {{ postgresql_dist_redhat.basename }}-server{{
+         postgresql_dist_redhat.version_suffix }}
     state: present
 
 - name: postgres | install extension packages
   become: true
   yum:
     name: >-
-      {{ postgresql_dist.redhat.basename }}-contrib{{
-         postgresql_dist.redhat.version_suffix }}
+      {{ postgresql_dist_redhat.basename }}-contrib{{
+         postgresql_dist_redhat.version_suffix }}
     state: present
 
 - name: postgres | install ansible prerequisites
@@ -27,4 +27,16 @@
       }}-psycopg2
     state: present
     disablerepo: "*"
-    enablerepo: "{{ postgresql_dist.redhat.repoid }}"
+    enablerepo: "{{ postgresql_dist_redhat.repoid }}"
+
+- name: postgres | set redhat dist variables
+  set_fact:
+    postgresql_dist_datadir: "{{ postgresql_dist_redhat.datadir }}"
+    postgresql_dist_bindir: "{{ postgresql_dist_redhat.bindir }}"
+    postgresql_dist_confdir: "{{ postgresql_dist_redhat.confdir }}"
+    postgresql_dist_setup: >-
+      {{ postgresql_dist_redhat.bindir }}/{{ postgresql_dist_redhat.setupname }}
+      initdb
+    postgresql_dist_service: "{{ postgresql_dist_redhat.service }}"
+    postgresql_dist_conf_postgresql_src: >-
+      {{ postgresql_dist_redhat.conf_postgresql_src }}


### PR DESCRIPTION
Before jumping into it: really appreciate the work done here together with the GitHub actions pipeline + Molecule action. Thank you for sharing these gems!

Debian doesn't (strictly) depend on the values coming from
https://github.com/ome/ansible-role-postgresql-client/blob/master/vars/main.yml#L5-L21

but it will still fail at

https://github.com/ome/ansible-role-postgresql/blob/ffb2effedc5514bfc0fbac2be72fad223cfa8168/tasks/initialise.yml#L14-L26

since that will try to load default values for RedHat (+ versions).

Setting Postgres versions that aren't previously defined on PostgreSQL client (e.g. 13, 14) are working just fine on Debian after implementing these changes.

To segregate both installations, the values are now set using `set_fact` inside its own distro's tasks file, which corresponds to the conditional on tasks/main.yml and ensures consistency.

Some bonus changes:
+ included a block on tasks to have become+become_user defined less
  times;
+ added a variable to change the user that it will become when asked.