### PR TITLE
 PostgreSQL versions & platform support updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Role Variables
 
 Defaults: `defaults/main.yml`
 
-- `postgresql_version`: The PostgreSQL major version: `10`, `11`, `12`
+- `postgresql_version`: The PostgreSQL major version: `10`, `11`, `12`, `13`
 - `postgresql_package_version`: The PostgreSQL full version, leave this empty to use the latest minor release from `postgresql_version`, ignored on Ubuntu
 - `postgresql_dist_redhat` or `postgresql_dist_debian`: Object that define configuration attributes for PostgreSQL on each specific OS, these variables allow to change the interaction between variables defined at [ome.postgresql](https://galaxy.ansible.com/ome/postgresql) and [ome.postgresql_client](https://github.com/ome/ansible-role-postgresql-client)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,17 +38,14 @@ postgresql_server_chown_datadir: false
 # Attributes are parsed and used to set facts at tasks/redhat.yml.
 # Overriding the default values allow to configure future versions of
 # PostgreSQL, e.g. different paths according to the version, config, etc.
-# NOTE: Default values rely on variable postgresql_distribution_redhat, which is
-# by default set at ome.postgresql_client.
 postgresql_dist_redhat:
   bindir: /usr/pgsql-{{ postgresql_version }}/bin
   confdir: /var/lib/pgsql/{{ postgresql_version }}/data
   conf_postgresql_src: postgresql-conf.j2
   datadir: /var/lib/pgsql/{{ postgresql_version }}/data
-  basename: >-
-    {{ postgresql_distribution_redhat[postgresql_version].basename }}
-  repoid: "{{ postgresql_distribution_redhat[postgresql_version].repo }}"
-  setupname: "{{ postgresql_distribution_redhat[postgresql_version].setup }}"
+  basename: postgresql{{ postgresql_version }}
+  repoid: pgdg{{ postgresql_version }}
+  setupname: postgresql-{{ postgresql_version }}-setup
   service: postgresql-{{ postgresql_version }}
   version_suffix: >-
     {{

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
   role_name: postgresql
   galaxy_tags: ['postgresql', 'database']
 

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -27,6 +27,13 @@ platforms:
     privileged: true
     groups:
       - extra_options
+  - name: postgresql-13-c7
+    image: centos/systemd
+    image_version: latest
+    command: /sbin/init
+    privileged: true
+    groups:
+      - extra_options
 provisioner:
   name: ansible
   lint:
@@ -39,6 +46,8 @@ provisioner:
         postgresql_version: "11"
       postgresql-12-c7:
         postgresql_version: "12"
+      postgresql-13-c7:
+        postgresql_version: "13"
     group_vars:
       extra_options:
         postgresql_server_conf:

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -29,8 +29,7 @@ def test_databases(host, name, expected_db):
 
 
 def test_server_listen(host):
-    hostname = host.backend.get_hostname()
-    version = get_version(hostname)
+    version = get_version(host)
     if host.system_info.distribution == 'centos':
         configfile = '/var/lib/pgsql/{version}/data/postgresql.conf'
     else:
@@ -50,7 +49,7 @@ def test_server_listen(host):
 
 
 def test_psql_version(host):
-    ver = get_version(host.backend.get_hostname())
+    ver = get_version(host)
     out = host.check_output('psql --version')
     assert out.startswith('psql (PostgreSQL) {}.'.format(ver))
 

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -3,7 +3,7 @@ import pytest
 import testinfra.utils.ansible_runner
 import uuid
 from re import match
-from utils import get_distribution, get_version
+from utils import get_version
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
@@ -16,13 +16,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     ('secretdb', 'secretdb|{lang}.UTF-8|{lang}.UTF-8')
 ])
 def test_databases(host, name, expected_db):
-    hostname = host.backend.get_hostname()
     sql = ("SELECT datname,datcollate,datctype FROM pg_database "
            "WHERE datname='%s'" % name)
     with host.sudo('postgres'):
         out = host.check_output('psql postgres -c "%s" -At' % sql)
 
-    if get_distribution(hostname) == 'centos':
+    if host.system_info.distribution == 'centos':
         lang = 'en_US'
     else:
         lang = 'C'
@@ -32,7 +31,7 @@ def test_databases(host, name, expected_db):
 def test_server_listen(host):
     hostname = host.backend.get_hostname()
     version = get_version(hostname)
-    if get_distribution(hostname) == 'centos':
+    if host.system_info.distribution == 'centos':
         configfile = '/var/lib/pgsql/{version}/data/postgresql.conf'
     else:
         configfile = '/etc/postgresql/{version}/main/postgresql.conf'

--- a/molecule/resources/tests/test_extra_options.py
+++ b/molecule/resources/tests/test_extra_options.py
@@ -8,8 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_server_additional_config(host):
-    hostname = host.backend.get_hostname()
-    version = get_version(hostname)
+    version = get_version(host)
     if host.system_info.distribution == 'centos':
         configfile = '/var/lib/pgsql/{version}/data/postgresql.conf'
     else:
@@ -22,8 +21,7 @@ def test_server_additional_config(host):
 
 def test_server_log_file_name(host):
     # Check previous day too in case this is run at midnight
-    hostname = host.backend.get_hostname()
-    version = get_version(hostname)
+    version = get_version(host)
     if host.system_info.distribution == 'centos':
         logdir = '/var/lib/pgsql/{version}/data/pg_log'
     else:

--- a/molecule/resources/tests/test_extra_options.py
+++ b/molecule/resources/tests/test_extra_options.py
@@ -1,7 +1,7 @@
 import os
 import testinfra.utils.ansible_runner
 from datetime import datetime, timedelta
-from utils import get_distribution, get_version
+from utils import get_version
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('extra_options')
@@ -10,7 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_server_additional_config(host):
     hostname = host.backend.get_hostname()
     version = get_version(hostname)
-    if get_distribution(hostname) == 'centos':
+    if host.system_info.distribution == 'centos':
         configfile = '/var/lib/pgsql/{version}/data/postgresql.conf'
     else:
         configfile = '/etc/postgresql/{version}/main/postgresql.conf'
@@ -24,7 +24,7 @@ def test_server_log_file_name(host):
     # Check previous day too in case this is run at midnight
     hostname = host.backend.get_hostname()
     version = get_version(hostname)
-    if get_distribution(hostname) == 'centos':
+    if host.system_info.distribution == 'centos':
         logdir = '/var/lib/pgsql/{version}/data/pg_log'
     else:
         logdir = '/var/lib/postgresql/{version}/main/pg_log'

--- a/molecule/resources/tests/utils.py
+++ b/molecule/resources/tests/utils.py
@@ -1,18 +1,3 @@
-# Enumerate instead of parsing so we pick up errors if a host is added/changed
-ver_lookup = {
-    "postgresql-10-c7": ("10", "centos"),
-    "postgresql-11-c7": ("11", "centos"),
-    "postgresql-12-c7": ("12", "centos"),
-
-    "postgresql-10-u1804": ("10", "ubuntu"),
-    "postgresql-11-u1804": ("11", "ubuntu"),
-    "postgresql-12-u1804": ("12", "ubuntu"),
-}
-
-
-def get_distribution(hostname):
-    return ver_lookup[hostname][1]
-
-
-def get_version(hostname):
-    return ver_lookup[hostname][0]
+def get_version(host):
+    variables = host.ansible.get_variables()
+    return variables["postgresql_version"]

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -28,6 +28,12 @@ platforms:
     privileged: true
     tmpfs:
       - /sys/fs/cgroup
+  - name: postgresql-13-u1804
+    image: leandelivery/docker-systemd:ubuntu-18.04
+    command: /sbin/init
+    privileged: true
+    tmpfs:
+      - /sys/fs/cgroup
 provisioner:
   name: ansible
   lint:
@@ -42,6 +48,9 @@ provisioner:
         ansible_python_interpreter: /usr/bin/python3
       postgresql-12-u1804:
         postgresql_version: "12"
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-13-u1804:
+        postgresql_version: "13"
         ansible_python_interpreter: /usr/bin/python3
     group_vars:
       extra_options:

--- a/molecule/ubuntu2004/Dockerfile.j2
+++ b/molecule/ubuntu2004/Dockerfile.j2
@@ -1,0 +1,1 @@
+../resources/Dockerfile.j2

--- a/molecule/ubuntu2004/molecule.yml
+++ b/molecule/ubuntu2004/molecule.yml
@@ -28,6 +28,12 @@ platforms:
     privileged: true
     tmpfs:
       - /sys/fs/cgroup
+  - name: postgresql-13-u2004
+    image: jrei/systemd-ubuntu:20.04
+    command: /sbin/init
+    privileged: true
+    tmpfs:
+      - /sys/fs/cgroup
 provisioner:
   name: ansible
   lint:
@@ -42,6 +48,9 @@ provisioner:
         ansible_python_interpreter: /usr/bin/python3
       postgresql-12-u2004:
         postgresql_version: "12"
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-13-u2004:
+        postgresql_version: "13"
         ansible_python_interpreter: /usr/bin/python3
     group_vars:
       extra_options:

--- a/molecule/ubuntu2004/molecule.yml
+++ b/molecule/ubuntu2004/molecule.yml
@@ -1,0 +1,59 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/resources/requirements.yml
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: postgresql-10-u2004
+    image: jrei/systemd-ubuntu:20.04
+    command: /sbin/init
+    privileged: true
+    tmpfs:
+      - /sys/fs/cgroup
+    groups:
+      - extra_options
+  - name: postgresql-11-u2004
+    image: jrei/systemd-ubuntu:20.04
+    command: /sbin/init
+    privileged: true
+    tmpfs:
+      - /sys/fs/cgroup
+  - name: postgresql-12-u2004
+    image: jrei/systemd-ubuntu:20.04
+    command: /sbin/init
+    privileged: true
+    tmpfs:
+      - /sys/fs/cgroup
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    host_vars:
+      postgresql-10-u2004:
+        postgresql_version: "10"
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-11-u2004:
+        postgresql_version: "11"
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-12-u2004:
+        postgresql_version: "12"
+        ansible_python_interpreter: /usr/bin/python3
+    group_vars:
+      extra_options:
+        postgresql_server_conf:
+          shared_preload_libraries: "'pg_stat_statements'"
+          log_filename: "'postgresql-%F.log'"
+  playbooks:
+    converge: ../resources/playbook.yml
+scenario:
+  name: ubuntu2004
+verifier:
+  name: testinfra
+  directory: ../resources/tests/
+  lint:
+    name: flake8

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -26,8 +26,6 @@
         ansible_python_version is version('3.0.0', '<') | ternary('2', '3')
       }}-psycopg2
     state: present
-    disablerepo: "*"
-    enablerepo: "{{ postgresql_dist_redhat.repoid }}"
 
 - name: postgres | set redhat dist variables
   set_fact:


### PR DESCRIPTION
Follow-up to https://github.com/ome/ansible-role-postgresql-client/pull/5 and related to the investigation of #27, this PR:

- adds Ubuntu 20.04 to the platforms tested by Molecule and supported by the role
- adds PostgreSQL 13 to the list of versions tested by Molecule
- drops the usage of the deprecated `postgresql_distribution_redhat` variable as the RedHat variables can be constructed from the version directly like on Debian
- simplify the Molecule tests to make use of built-in `testinfra` features (`host.system_info`, `host.ansible`) and remove the maintaining of a dictionary mapping hostnames to versions/distributions

db4a1d54ae097262071362c2a2260473470d32db removes a special handling of the `psycopg2` installation which caused the installation of PSQL 13 to fail (see https://github.com/sbesson/ansible-role-postgresql/runs/6525049967?check_suite_focus=true) with 

```
    fatal: [postgresql-13-c7]: FAILED! => {"changed": false, "msg": "No package matching 'python2-psycopg2' found available, installed or updated", "rc": 126, "results": ["No package matching 'python2-psycopg2' found available, installed or updated"]}
```

This workaround was introduced in https://github.com/ome/ansible-role-postgresql/pull/17. Looking at the original issue posted on the mailing list, it was an upstream suggestion applicable toversions PSQL 9.6 and earlier made in https://www.postgresql.org/message-id/9a97200b9bc167297e88f7be482634ddfb340ccf.camel%40gunduz.org and should be unncessary now that only PSQL 10+ are available in the RedHat repositories.

The addition of PSQL 14 to the Molecule scenarios  currently fails the idempotence tests. This is quite possibly related to #27  and I will investigate separately.