### PR TITLE
Update to use Rockylinux 9 and Ubuntu 22.04

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   list-scenarios:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
@@ -22,7 +22,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -45,7 +45,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: galaxy
         uses: ome/action-ansible-galaxy-publish@main

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,4 +17,7 @@ galaxy_info:
   galaxy_tags: ['postgresql', 'database']
 
 dependencies:
-  - role: ome.postgresql_client
+  - src: https://github.com/khaledk2/ansible-role-postgresql-client/
+    scm: git
+    version: update_to_rockylinux9_and_ubuntu2204
+    name: postgresql_client

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,10 +8,10 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 9
     - name: Ubuntu
       versions:
-        - focal
+        - jammy
   namespace: ome
   role_name: postgresql
   galaxy_tags: ['postgresql', 'database']

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,4 @@ galaxy_info:
   galaxy_tags: ['postgresql', 'database']
 
 dependencies:
-  - src: https://github.com/khaledk2/ansible-role-postgresql-client/
-    scm: git
-    version: update_to_rockylinux9_and_ubuntu2204
-    name: postgresql_client
+  - role: postgresql_client

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,4 +17,4 @@ galaxy_info:
   galaxy_tags: ['postgresql', 'database']
 
 dependencies:
-  - role: postgresql_client
+  - role: ome.postgresql_client

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -1,2 +1,2 @@
 ---
-- name: ome.postgresql_client
+- src: ome.postgresql_client

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -1,2 +1,4 @@
 ---
-- src: ome.postgresql_client
+- name: postgresql_client
+  src: https://github.com/khaledk2/ansible-role-postgresql-client/
+  version: update_to_rockylinux9_and_ubuntu2204

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -1,4 +1,2 @@
 ---
-- name: postgresql_client
-  src: https://github.com/khaledk2/ansible-role-postgresql-client/
-  version: update_to_rockylinux9_and_ubuntu2204
+- name: ome.postgresql_client

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -21,7 +21,7 @@ def test_databases(host, name, expected_db):
     with host.sudo('postgres'):
         out = host.check_output('psql postgres -c "%s" -At' % sql)
 
-    if host.system_info.distribution == 'centos':
+    if host.system_info.distribution == 'rocky':
         lang = 'en_US'
     else:
         lang = 'C'
@@ -30,7 +30,7 @@ def test_databases(host, name, expected_db):
 
 def test_server_listen(host):
     version = get_version(host)
-    if host.system_info.distribution == 'centos':
+    if host.system_info.distribution == 'rocky':
         configfile = '/var/lib/pgsql/{version}/data/postgresql.conf'
     else:
         configfile = '/etc/postgresql/{version}/main/postgresql.conf'

--- a/molecule/resources/tests/test_extra_options.py
+++ b/molecule/resources/tests/test_extra_options.py
@@ -9,7 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_server_additional_config(host):
     version = get_version(host)
-    if host.system_info.distribution == 'centos':
+    if host.system_info.distribution == 'rocky':
         configfile = '/var/lib/pgsql/{version}/data/postgresql.conf'
     else:
         configfile = '/etc/postgresql/{version}/main/postgresql.conf'
@@ -22,7 +22,7 @@ def test_server_additional_config(host):
 def test_server_log_file_name(host):
     # Check previous day too in case this is run at midnight
     version = get_version(host)
-    if host.system_info.distribution == 'centos':
+    if host.system_info.distribution == 'rocky':
         logdir = '/var/lib/pgsql/{version}/data/pg_log'
     else:
         logdir = '/var/lib/postgresql/{version}/main/pg_log'

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -15,6 +15,9 @@ platforms:
     image_version: latest
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
     groups:
       - extra_options
   - name: postgresql-12-r9
@@ -22,6 +25,9 @@ platforms:
     image_version: latest
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
     groups:
       - extra_options
   - name: postgresql-13-r9
@@ -29,6 +35,9 @@ platforms:
     image_version: latest
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
     groups:
       - extra_options
   - name: postgresql-14-r9
@@ -36,6 +45,9 @@ platforms:
     image_version: latest
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
     groups:
       - extra_options
 provisioner:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -10,48 +10,48 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: postgresql-11-u2004
-    image: jrei/systemd-ubuntu:20.04
+  - name: postgresql-11-r9
+    image: eniocarboni/docker-rockylinux-systemd:9
+    image_version: latest
     command: /sbin/init
     privileged: true
-    tmpfs:
-      - /sys/fs/cgroup
-  - name: postgresql-12-u2004
-    image: jrei/systemd-ubuntu:20.04
+    groups:
+      - extra_options
+  - name: postgresql-12-r9
+    image: eniocarboni/docker-rockylinux-systemd:9
+    image_version: latest
     command: /sbin/init
     privileged: true
-    tmpfs:
-      - /sys/fs/cgroup
-  - name: postgresql-13-u2004
-    image: jrei/systemd-ubuntu:20.04
+    groups:
+      - extra_options
+  - name: postgresql-13-r9
+    image: eniocarboni/docker-rockylinux-systemd:9
+    image_version: latest
     command: /sbin/init
     privileged: true
-    tmpfs:
-      - /sys/fs/cgroup
-  - name: postgresql-14-u2004
-    image: jrei/systemd-ubuntu:20.04
+    groups:
+      - extra_options
+  - name: postgresql-14-r9
+    image: eniocarboni/docker-rockylinux-systemd:9
+    image_version: latest
     command: /sbin/init
     privileged: true
-    tmpfs:
-      - /sys/fs/cgroup
+    groups:
+      - extra_options
 provisioner:
   name: ansible
   lint:
     name: ansible-lint
   inventory:
     host_vars:
-      postgresql-11-u2004:
+      postgresql-11-r9:
         postgresql_version: "11"
-        ansible_python_interpreter: /usr/bin/python3
-      postgresql-12-u2004:
+      postgresql-12-r9:
         postgresql_version: "12"
-        ansible_python_interpreter: /usr/bin/python3
-      postgresql-13-u2004:
+      postgresql-13-r9:
         postgresql_version: "13"
-        ansible_python_interpreter: /usr/bin/python3
-      postgresql-14-u2004:
+      postgresql-14-r9:
         postgresql_version: "14"
-        ansible_python_interpreter: /usr/bin/python3
     group_vars:
       extra_options:
         postgresql_server_conf:
@@ -60,7 +60,7 @@ provisioner:
   playbooks:
     converge: ../resources/playbook.yml
 scenario:
-  name: ubuntu2004
+  name: rockylinux9
 verifier:
   name: testinfra
   directory: ../resources/tests/

--- a/molecule/rockylinux9/prepare.yml
+++ b/molecule/rockylinux9/prepare.yml
@@ -4,7 +4,8 @@
   hosts: all
   tasks:
     - name: Upgrade ca-certificates
-      yum:
+      ansible.builtin.dnf:
+        update_cache: true
         pkg:
           - ca-certificates
         state: latest

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -14,24 +14,28 @@ platforms:
     image:  eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
     tmpfs:
       - /sys/fs/cgroup
   - name: postgresql-12-u2204
     image:  eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
     tmpfs:
       - /sys/fs/cgroup
   - name: postgresql-13-u2204
     image: eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
     tmpfs:
       - /sys/fs/cgroup
   - name: postgresql-14-u2204
     image: eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
+    cgroupns_mode: host
     tmpfs:
       - /sys/fs/cgroup
 provisioner:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -10,48 +10,48 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: postgresql-11-c7
-    image: centos/systemd
-    image_version: latest
+  - name: postgresql-11-u2204
+    image:  eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
-    groups:
-      - extra_options
-  - name: postgresql-12-c7
-    image: centos/systemd
-    image_version: latest
+    tmpfs:
+      - /sys/fs/cgroup
+  - name: postgresql-12-u2204
+    image:  eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
-    groups:
-      - extra_options
-  - name: postgresql-13-c7
-    image: centos/systemd
-    image_version: latest
+    tmpfs:
+      - /sys/fs/cgroup
+  - name: postgresql-13-u2204
+    image: eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
-    groups:
-      - extra_options
-  - name: postgresql-14-c7
-    image: centos/systemd
-    image_version: latest
+    tmpfs:
+      - /sys/fs/cgroup
+  - name: postgresql-14-u2204
+    image: eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
-    groups:
-      - extra_options
+    tmpfs:
+      - /sys/fs/cgroup
 provisioner:
   name: ansible
   lint:
     name: ansible-lint
   inventory:
     host_vars:
-      postgresql-11-c7:
+      postgresql-11-u2204:
         postgresql_version: "11"
-      postgresql-12-c7:
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-12-u2204:
         postgresql_version: "12"
-      postgresql-13-c7:
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-13-u2204:
         postgresql_version: "13"
-      postgresql-14-c7:
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-14-u2204:
         postgresql_version: "14"
+        ansible_python_interpreter: /usr/bin/python3
     group_vars:
       extra_options:
         postgresql_server_conf:
@@ -60,7 +60,7 @@ provisioner:
   playbooks:
     converge: ../resources/playbook.yml
 scenario:
-  name: centos7
+  name: ubuntu2204
 verifier:
   name: testinfra
   directory: ../resources/tests/

--- a/molecule/ubuntu2204/prepare.yml
+++ b/molecule/ubuntu2204/prepare.yml
@@ -3,5 +3,5 @@
 - name: Prepare all
   hosts: all
   tasks:
-    - apt:
+    - ansible.builtin.apt:
         update_cache: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,14 +3,16 @@
 
 - name: postgres | install packages
   become: true
-  apt:
+  ansible.builtin.apt:
+    update_cache: true
     name: >-
       {{ postgresql_dist_debian.basename }}
     state: present
 
 - name: postgres | install ansible prerequisites
   become: true
-  apt:
+  ansible.builtin.apt:
+    update_cache: true
     # Needs to match the Ansible interpreter
     name: >-
       python{{

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -30,7 +30,7 @@
       }}-psycopg2
     state: present
 
-- name: localectl set-locale LANG=en_US.utf8
+- name: get langpack for en
   become: true
   ansible.builtin.dnf:
     update_cache: true

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -30,6 +30,13 @@
       }}-psycopg2
     state: present
 
+- name: get langpack for en
+  become: true
+  ansible.builtin.dnf:
+    update_cache: true
+    name: glibc-langpack-en
+	state: present
+
 - name: postgres | set redhat dist variables
   set_fact:
     postgresql_dist_datadir: "{{ postgresql_dist_redhat.datadir }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,9 +1,10 @@
 ---
-# tasks file for ome.postgresql centos
+# tasks file for ome.postgresql rocky
 
 - name: postgres | install server packages
   become: true
-  yum:
+  ansible.builtin.dnf:
+    update_cache: true
     name: >-
       {{ postgresql_dist_redhat.basename }}-server{{
          postgresql_dist_redhat.version_suffix }}
@@ -11,7 +12,8 @@
 
 - name: postgres | install extension packages
   become: true
-  yum:
+  ansible.builtin.dnf:
+    update_cache: true
     name: >-
       {{ postgresql_dist_redhat.basename }}-contrib{{
          postgresql_dist_redhat.version_suffix }}
@@ -19,7 +21,8 @@
 
 - name: postgres | install ansible prerequisites
   become: true
-  yum:
+  ansible.builtin.dnf:
+    update_cache: true
     # Needs to match the Ansible interpreter
     name: >-
       python{{

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -30,12 +30,12 @@
       }}-psycopg2
     state: present
 
-- name: get langpack for en
+- name: localectl set-locale LANG=en_US.utf8
   become: true
   ansible.builtin.dnf:
     update_cache: true
     name: glibc-langpack-en
-	state: present
+    state: present
 
 - name: postgres | set redhat dist variables
   set_fact:


### PR DESCRIPTION
It failed for Rocky Linux 9 with this error
https://github.com/khaledk2/ansible-role-postgresql/actions/runs/6275413708/job/17042853222#step:5:192
I think it uses [ome.postgresql_client](https://github.com/ome/ansible-role-postgresql-client) and this should be resolved after merging  [PR 8](https://github.com/ome/ansible-role-postgresql-client/pull/8) for postgresql_client
