### PR TITLE
Psql bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 Defaults: `defaults/main.yml`
 
-- `postgresql_version`: The PostgreSQL major version: `12`, `13`, `14`, `15`
+- `postgresql_version`: The PostgreSQL major version: `12`, `13`, `14`, `15`, `16`
 - `postgresql_package_version`: The PostgreSQL full version, leave this empty to use the latest minor release from `postgresql_version`, ignored on Ubuntu
 - `postgresql_dist_redhat` or `postgresql_dist_debian`: Object that define configuration attributes for PostgreSQL on each specific OS, these variables allow to change the interaction between variables defined at [ome.postgresql](https://galaxy.ansible.com/ome/postgresql) and [ome.postgresql_client](https://github.com/ome/ansible-role-postgresql-client)
 
@@ -34,6 +34,7 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   - `password`: Database user password
   - `databases`: List of databases that user can connect to, required but can be empty `[]`
   - `roles`: Role attribute flags, optional
+  - `privileges`: Privilege granted
   If you want the user to have restricted access see the section below on Restricted users.
 - `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `'*'` for all
 - `postgresql_server_conf`: Dictionary of additional postgresql.conf options

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   - `password`: Database user password
   - `databases`: List of databases that user can connect to, required but can be empty `[]`
   - `roles`: Role attribute flags, optional
-  - `privileges`: Privilege granted
   If you want the user to have restricted access see the section below on Restricted users.
 - `postgresql_server_listen`: Listen on these interfaces, default `localhost`, use `'*'` for all
 - `postgresql_server_conf`: Dictionary of additional postgresql.conf options

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Install upstream PostgreSQL server.
 
 Optionally creates users and databases.
 If you wish to use your distribution's packages then do not use this role.
+This role revokes default `PUBLIC` privileges from database and `public` schema for all supported versions of PostgreSQL.
+This is to be inline with the breaking privileges made in PostgreSQL 15.
 
 Role Variables
 --------------
@@ -27,7 +29,6 @@ The following parameters will be ignored if `postgresql_install_server: False`:
   - `lc_ctype`: Character classification (LC_CTYPE) to use in the database
   - `encoding`: Encoding of the database, default `UTF-8`
   - `template`: Template used to create the database
-  - `restrict`: If `True` revoke default `PUBLIC` privileges from database and `public` schema, default `False`
 - `postgresql_users`: List of dictionaries of users.
   Items should be of the form:
   - `user`: Database username
@@ -50,7 +51,7 @@ Restricted databases
 --------------------
 
 In general it is not possible to create users with restricted access (e.g. read-only users) until a schema has been populated.
-This role optionally removes the default PUBLIC privileges from all databases, then grants:
+This role removes the default PUBLIC privileges from all databases, then grants:
 - `ALL` privileges to the database owner if specified (`postgresql_databases[].owner`)
 - `CONNECT` privilege to the database, and `USAGE` privilege on the `public` schema, to databases listed for each user (`postgresql_users[].databases`)
 
@@ -96,7 +97,6 @@ Example Playbook
       - postgresql_databases:
         - name: secretdb
           owner: alice
-          restrict: True
       - postgresql_users:
         - user: alice
           password: alice123

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install upstream PostgreSQL server.
 Optionally creates users and databases.
 If you wish to use your distribution's packages then do not use this role.
 This role revokes default `PUBLIC` privileges from database and `public` schema for all supported versions of PostgreSQL.
-This is to be inline with the breaking privileges made in PostgreSQL 15.
+This is to be inline with the breaking change made in PostgreSQL 15.
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Role Variables
 
 Defaults: `defaults/main.yml`
 
-- `postgresql_version`: The PostgreSQL major version: `12`, `13`, `14`
+- `postgresql_version`: The PostgreSQL major version: `12`, `13`, `14`, `15`
 - `postgresql_package_version`: The PostgreSQL full version, leave this empty to use the latest minor release from `postgresql_version`, ignored on Ubuntu
 - `postgresql_dist_redhat` or `postgresql_dist_debian`: Object that define configuration attributes for PostgreSQL on each specific OS, these variables allow to change the interaction between variables defined at [ome.postgresql](https://galaxy.ansible.com/ome/postgresql) and [ome.postgresql_client](https://github.com/ome/ansible-role-postgresql-client)
 

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -7,7 +7,6 @@
         - name: publicdb
         - name: secretdb
           owner: alice
-          restrict: true
       postgresql_users:
         - user: alice
           password: alice123

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -12,7 +12,6 @@
         - user: alice
           password: alice123
           # alice is the owner of secretdb so already has access
-          privilege: "ALL"
           databases: [publicdb]
         - user: bob
           password: bob123
@@ -21,12 +20,16 @@
         - user: charles
           password: charles123
           databases: []
+        - user: tester
+          password: tester123
+          databases: [publicdb, secretdb]
+          roles: "SUPERUSER"
 
 - hosts: all
   tasks:
     - name: create test tables publicdb
       command: >
-        env PGPASSWORD=alice123 psql -h localhost -U alice publicdb
+        env PGPASSWORD=tester123 psql -h localhost -U tester publicdb
         -c "{{ item }}"
       register: result
       changed_when: >

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -12,6 +12,7 @@
         - user: alice
           password: alice123
           # alice is the owner of secretdb so already has access
+          privilege: "ALL"
           databases: [publicdb]
         - user: bob
           password: bob123

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -22,7 +22,7 @@
           databases: []
         - user: tester
           password: tester123
-          databases: [publicdb, secretdb]
+          databases: []
           roles: "SUPERUSER"
 
 - hosts: all

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -99,7 +99,7 @@ def test_user_roles(host, name, expected_roles):
 
 # Owner and users with SELECT privileges can read
 @pytest.mark.parametrize("name,database,table,should_pass", [
-    ('alice', 'publicdb', "regular", True),
+    ('alice', 'publicdb', "regular", False),
     ('alice', 'secretdb', "regular", True),
     ('alice', 'secretdb', "password", True),
 
@@ -122,7 +122,7 @@ def test_select(host, name, database, table, should_pass):
 
 
 # Default PUBLIC allows anyone with access to create a table
-# This is removed if restrict was set
+# in publicdb for psql version < 15
 @pytest.mark.parametrize("name,database,should_pass", [
     ('alice', 'publicdb', True),
     ('alice', 'secretdb', True),
@@ -130,7 +130,7 @@ def test_select(host, name, database, table, should_pass):
     ('bob', 'publicdb', True),
     ('bob', 'secretdb', False),
 
-    # TODO: charles can create tables in publicdb, is this expected?
+    # TODO: charles can create tables in publicdb, in version < 15
     ('charles', 'publicdb', True),
     ('charles', 'secretdb', False),
 ])
@@ -140,7 +140,7 @@ def test_create_table(host, name, database, should_pass):
     c = psql(host, database, sql, name)
     # Check version
     ver = get_version(host)
-    if name != 'alice' and database == 'publicdb' and ver >= "15":
+    if database == 'publicdb' and ver >= "15":
         should_pass = False
     if should_pass:
         assert c.rc == 0
@@ -150,7 +150,7 @@ def test_create_table(host, name, database, should_pass):
 
 
 @pytest.mark.parametrize("name,database,table,should_pass", [
-    ('alice', 'publicdb', "regular", True),
+    ('alice', 'publicdb', "regular", False),
     ('alice', 'secretdb', "regular", True),
     ('alice', 'secretdb', "password", True),
 

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -126,8 +126,6 @@ def test_select(host, name, database, table, should_pass):
         assert 'permission denied' in c.stderr
 
 
-# Default PUBLIC allows anyone with access to create a table
-# in publicdb for psql version < 15
 @pytest.mark.parametrize("name,database,should_pass", [
     ('tester', 'publicdb', True),
     ('tester', 'secretdb', True),
@@ -138,7 +136,6 @@ def test_select(host, name, database, table, should_pass):
     ('bob', 'publicdb', False),
     ('bob', 'secretdb', False),
 
-    # TODO: charles can create tables in publicdb, in version < 15
     ('charles', 'publicdb', False),
     ('charles', 'secretdb', False),
 ])

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -138,6 +138,8 @@ def test_create_table(host, name, database, should_pass):
     rnd = 'table_' + str(uuid.uuid4()).replace('-', '')
     sql = "CREATE TABLE %s (text text primary key);" % rnd
     c = psql(host, database, sql, name)
+    # Check version
+    ver = get_version(host)
     if name != 'alice' and database == 'publicdb' and ver >= "15":
         should_pass = False
     if should_pass:

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -99,6 +99,10 @@ def test_user_roles(host, name, expected_roles):
 
 # Owner and users with SELECT privileges can read
 @pytest.mark.parametrize("name,database,table,should_pass", [
+    ('tester', 'publicdb', "regular", True),
+    ('tester', 'secretdb', "regular", True),
+    ('tester', 'secretdb', "password", True),
+
     ('alice', 'publicdb', "regular", False),
     ('alice', 'secretdb', "regular", True),
     ('alice', 'secretdb', "password", True),
@@ -124,6 +128,9 @@ def test_select(host, name, database, table, should_pass):
 # Default PUBLIC allows anyone with access to create a table
 # in publicdb for psql version < 15
 @pytest.mark.parametrize("name,database,should_pass", [
+    ('tester', 'publicdb', True),
+    ('tester', 'secretdb', True),
+
     ('alice', 'publicdb', True),
     ('alice', 'secretdb', True),
 
@@ -140,7 +147,7 @@ def test_create_table(host, name, database, should_pass):
     c = psql(host, database, sql, name)
     # Check version
     ver = get_version(host)
-    if database == 'publicdb' and ver >= "15":
+    if name != 'tester' and database == 'publicdb' and ver >= "15":
         should_pass = False
     if should_pass:
         assert c.rc == 0
@@ -150,6 +157,10 @@ def test_create_table(host, name, database, should_pass):
 
 
 @pytest.mark.parametrize("name,database,table,should_pass", [
+    ('tester', 'publicdb', "regular", True),
+    ('tester', 'secretdb', "regular", True),
+    ('tester', 'secretdb', "password", True),
+
     ('alice', 'publicdb', "regular", False),
     ('alice', 'secretdb', "regular", True),
     ('alice', 'secretdb', "password", True),

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -146,10 +146,6 @@ def test_create_table(host, name, database, should_pass):
     rnd = 'table_' + str(uuid.uuid4()).replace('-', '')
     sql = "CREATE TABLE %s (text text primary key);" % rnd
     c = psql(host, database, sql, name)
-    # Check version
-    ver = get_version(host)
-    if name != 'tester' and database == 'publicdb' and ver >= "15":
-        should_pass = False
     if should_pass:
         assert c.rc == 0
         assert 'CREATE TABLE' in c.stdout

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -138,6 +138,8 @@ def test_create_table(host, name, database, should_pass):
     rnd = 'table_' + str(uuid.uuid4()).replace('-', '')
     sql = "CREATE TABLE %s (text text primary key);" % rnd
     c = psql(host, database, sql, name)
+    if name != 'alice' and database == 'publicdb' and ver >= "15":
+        should_pass = False
     if should_pass:
         assert c.rc == 0
         assert 'CREATE TABLE' in c.stdout

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -67,6 +67,7 @@ def createdb(host, db, should_pass, password, name):
 
 
 @pytest.mark.parametrize("name,password,should_pass", [
+    ('tester', 'tester123', True),
     ('alice', 'alice123', False),
     ('bob', 'bob123', True),
     ('charles', 'charles123', False),
@@ -131,14 +132,14 @@ def test_select(host, name, database, table, should_pass):
     ('tester', 'publicdb', True),
     ('tester', 'secretdb', True),
 
-    ('alice', 'publicdb', True),
+    ('alice', 'publicdb', False),
     ('alice', 'secretdb', True),
 
-    ('bob', 'publicdb', True),
+    ('bob', 'publicdb', False),
     ('bob', 'secretdb', False),
 
     # TODO: charles can create tables in publicdb, in version < 15
-    ('charles', 'publicdb', True),
+    ('charles', 'publicdb', False),
     ('charles', 'secretdb', False),
 ])
 def test_create_table(host, name, database, should_pass):

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -87,6 +87,7 @@ def psql(host, database, sql, name):
 
 
 @pytest.mark.parametrize("name,expected_roles", [
+    ('tester', 'tester|t|t|f|f|t|f|-1|********||f||'),
     ('alice', 'alice|f|t|f|f|t|f|-1|********||f||'),
     ('bob', 'bob|f|t|f|t|t|f|-1|********||f||'),
 ])

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -50,6 +50,16 @@ platforms:
       - /sys/fs/cgroup
     groups:
       - extra_options
+  - name: postgresql-16-r9
+    image: eniocarboni/docker-rockylinux-systemd:9
+    image_version: latest
+    command: /sbin/init
+    privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
+    groups:
+      - extra_options
 provisioner:
   name: ansible
   lint:
@@ -64,6 +74,8 @@ provisioner:
         postgresql_version: "14"
       postgresql-15-r9:
         postgresql_version: "15"
+      postgresql-16-r9:
+        postgresql_version: "16"
     group_vars:
       extra_options:
         postgresql_server_conf:

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -40,6 +40,16 @@ platforms:
       - /sys/fs/cgroup
     groups:
       - extra_options
+  - name: postgresql-15-r9
+    image: eniocarboni/docker-rockylinux-systemd:9
+    image_version: latest
+    command: /sbin/init
+    privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
+    groups:
+      - extra_options
 provisioner:
   name: ansible
   lint:
@@ -52,6 +62,8 @@ provisioner:
         postgresql_version: "13"
       postgresql-14-r9:
         postgresql_version: "14"
+      postgresql-15-r9:
+        postgresql_version: "15"
     group_vars:
       extra_options:
         postgresql_server_conf:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -38,6 +38,13 @@ platforms:
     cgroupns_mode: host
     tmpfs:
       - /sys/fs/cgroup
+  - name: postgresql-16-u2204
+    image: eniocarboni/docker-ubuntu-systemd:22.04
+    command: /sbin/init
+    privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
 provisioner:
   name: ansible
   lint:
@@ -55,6 +62,9 @@ provisioner:
         ansible_python_interpreter: /usr/bin/python3
       postgresql-15-u2204:
         postgresql_version: "15"
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-16-u2204:
+        postgresql_version: "16"
         ansible_python_interpreter: /usr/bin/python3
     group_vars:
       extra_options:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -11,7 +11,7 @@ lint: |
   flake8
 platforms:
   - name: postgresql-12-u2204
-    image:  eniocarboni/docker-ubuntu-systemd:22.04
+    image: eniocarboni/docker-ubuntu-systemd:22.04
     command: /sbin/init
     privileged: true
     cgroupns_mode: host

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -31,6 +31,13 @@ platforms:
     cgroupns_mode: host
     tmpfs:
       - /sys/fs/cgroup
+  - name: postgresql-15-u2204
+    image: eniocarboni/docker-ubuntu-systemd:22.04
+    command: /sbin/init
+    privileged: true
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
 provisioner:
   name: ansible
   lint:
@@ -45,6 +52,9 @@ provisioner:
         ansible_python_interpreter: /usr/bin/python3
       postgresql-14-u2204:
         postgresql_version: "14"
+        ansible_python_interpreter: /usr/bin/python3
+      postgresql-15-u2204:
+        postgresql_version: "15"
         ansible_python_interpreter: /usr/bin/python3
     group_vars:
       extra_options:

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -55,7 +55,7 @@
         roles: PUBLIC
         state: absent
         type: database
-      when: "item.restrict | default(False)"
+      when: "item.restrict | default(True)"
       with_items:
         - "{{ postgresql_databases }}"
       changed_when: false
@@ -69,7 +69,7 @@
         roles: PUBLIC
         state: absent
         type: schema
-      when: "item.restrict | default(False)"
+      when: "item.restrict | default(True)"
       with_items:
         - "{{ postgresql_databases }}"
       changed_when: false

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -107,7 +107,6 @@
         roles: "{{ item.0.user }}"
         state: present
         type: schema
-      when: item.0.privilege is not defined
       with_subelements:
         - "{{ postgresql_users }}"
         - databases

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -112,18 +112,5 @@
         - "{{ postgresql_users }}"
         - databases
 
-    - name: postgres | grant specified privileges on default public schema
-      postgresql_privs:
-        database: "{{ item.1 }}"
-        objs: public
-        privs: "{{ item.0.privilege }}"
-        roles: "{{ item.0.user }}"
-        state: present
-        type: schema
-      when: item.0.privilege is defined
-      with_subelements:
-        - "{{ postgresql_users }}"
-        - databases
-
   become: true
   become_user: "{{ postgresql_become_user }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -55,7 +55,6 @@
         roles: PUBLIC
         state: absent
         type: database
-      when: "item.restrict | default(True)"
       with_items:
         - "{{ postgresql_databases }}"
       changed_when: false
@@ -69,7 +68,6 @@
         roles: PUBLIC
         state: absent
         type: schema
-      when: "item.restrict | default(True)"
       with_items:
         - "{{ postgresql_databases }}"
       changed_when: false

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -111,7 +111,7 @@
       with_subelements:
         - "{{ postgresql_users }}"
         - databases
-    
+
     - name: postgres | grant specified privileges on default public schema
       postgresql_privs:
         database: "{{ item.1 }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -107,6 +107,20 @@
         roles: "{{ item.0.user }}"
         state: present
         type: schema
+      when: item.0.privilege is not defined
+      with_subelements:
+        - "{{ postgresql_users }}"
+        - databases
+    
+    - name: postgres | grant specified privileges on default public schema
+      postgresql_privs:
+        database: "{{ item.1 }}"
+        objs: public
+        privs: "{{ item.0.privilege }}"
+        roles: "{{ item.0.user }}"
+        state: present
+        type: schema
+      when: item.0.privilege is defined
       with_subelements:
         - "{{ postgresql_users }}"
         - databases

--- a/templates/postgresql-conf-10-ubuntu.j2
+++ b/templates/postgresql-conf-10-ubuntu.j2
@@ -490,7 +490,7 @@ cluster_name = '{{ postgresql_version }}/main'			# added to process titles if no
 #track_io_timing = off
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
-stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_stat_tmp'
+{% if postgresql_version < 15 %}stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_stat_tmp'{% endif %}
 
 
 # - Statistics Monitoring -

--- a/templates/postgresql-conf-10-ubuntu.j2
+++ b/templates/postgresql-conf-10-ubuntu.j2
@@ -490,7 +490,7 @@ cluster_name = '{{ postgresql_version }}/main'			# added to process titles if no
 #track_io_timing = off
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
-{% if postgresql_version < 15 %}stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_stat_tmp'{% endif %}
+{% if postgresql_version < '15' %}stats_temp_directory = '/var/run/postgresql/{{ postgresql_version }}-main.pg_stat_tmp'{% endif %}
 
 
 # - Statistics Monitoring -


### PR DESCRIPTION
This PR ads support for psql 15+
version 15 and 16 have been added to the testing matrix
~~I had to introduce a new parameter to ``postgresql_users``~~
~~The changes should be backward compatible~~
The changes are **NOT** backward compatible
i cherry-picked the commit from #33 and fix warning introduced

i will fix the other warnings in a follow-up PR to simplify the review of the required changes to support psql 15+

cc @technics3 [mlukasik-dev](https://github.com/mlukasik-dev)

see https://www.postgresql.org/docs/release/15.0/ for background