### PR TITLE
WiP: Fix dependency

### DIFF
--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -60,7 +60,7 @@
       become: true
       become_user: postgres
       community.postgresql.postgresql_privs:
-        database: "{{ item }}"
+        login_db: "{{ item }}"
         obj: regular
         privs: SELECT
         roles: bob

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -50,7 +50,7 @@
 
     - name: postgres | revoke default permissions
       community.postgresql.postgresql_privs:
-        database: "{{ item.name }}"
+        login_db: "{{ item.name }}"
         privs: ALL
         roles: PUBLIC
         state: absent
@@ -62,7 +62,7 @@
     # Revoke the default permissions on the public schema
     - name: postgres | revoke default schema permissions
       community.postgresql.postgresql_privs:
-        database: "{{ item.name }}"
+        login_db: "{{ item.name }}"
         obj: public
         privs: ALL
         roles: PUBLIC
@@ -76,7 +76,7 @@
     # privileges are revoked we must grant them back to the owner
     - name: postgres | grant database owner public schema privileges
       community.postgresql.postgresql_privs:
-        database: "{{ item.name }}"
+        login_db: "{{ item.name }}"
         obj: public
         privs: ALL
         roles: "{{ item.owner }}"
@@ -88,7 +88,7 @@
 
     - name: postgres | grant connect privileges
       community.postgresql.postgresql_privs:
-        database: "{{ item.1 }}"
+        login_db: "{{ item.1 }}"
         privs: CONNECT
         roles: "{{ item.0.user }}"
         state: present
@@ -99,7 +99,7 @@
 
     - name: postgres | grant usage privileges on default public schema
       community.postgresql.postgresql_privs:
-        database: "{{ item.1 }}"
+        login_db: "{{ item.1 }}"
         objs: public
         privs: USAGE
         roles: "{{ item.0.user }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,5 +1,21 @@
 ---
 # tasks file for ome.postgresql rocky
+- name: Import a key for epel
+  become: true
+  ansible.builtin.rpm_key:
+    state: present
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+  when: ansible_os_family == 'RedHat'
+
+- name: epel | setup dnf repository
+  become: true
+  ansible.builtin.dnf:
+    update_cache: true
+    name:
+      https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    state: present
+  when: ansible_os_family == 'RedHat'
+
 
 - name: postgres | install server packages
   become: true

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,6 +1,16 @@
 ---
 # tasks file for ome.postgresql rocky
 
+- name: openssl | download rpm
+  become: true
+  ansible.builtin.dnf:
+    update_cache: true
+    name:
+      https://centos.pkgs.org/9-stream/centos-baseos-x86_64/openssl-libs-3.5.1-6.el9.x86_64.rpm
+    state: present
+  when: ansible_os_family == 'RedHat'
+
+
 - name: postgres | install server packages
   become: true
   ansible.builtin.dnf:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,21 +1,5 @@
 ---
 # tasks file for ome.postgresql rocky
-- name: Import a key for epel
-  become: true
-  ansible.builtin.rpm_key:
-    state: present
-    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
-  when: ansible_os_family == 'RedHat'
-
-- name: epel | setup dnf repository
-  become: true
-  ansible.builtin.dnf:
-    update_cache: true
-    name:
-      https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-    state: present
-  when: ansible_os_family == 'RedHat'
-
 
 - name: postgres | install server packages
   become: true


### PR DESCRIPTION
@khaledk2 @jburel 


Since very recently (only ``after`` we merged and tagged this repo at the beginning of Novermber 2025) the tests started to fail with 

```
   TASK [ome.postgresql : postgres | install extension packages] ******************
  Error: : Task failed: Module failed: Depsolve Error occurred:
   Problem: cannot install the best candidate for the job
    - nothing provides libcrypto.so.3(OPENSSL_3.4.0)(64bit) needed by postgresql16-contrib-16.11-1PGDG.rhel9.x86_64 from pgdg16
  Origin: /home/runner/work/ansible-role-postgresql/ansible-role-postgresql/tasks/redhat.yml:12:3
  
  10     state: present
  11
  12 - name: postgres | install extension packages
       ^ column 3
```

I am opening this PR as WiP - I think that the right way to fix it is to download the rpm first. But when I tried that way, the failure now says "payment required".

Maybe I am not finiding the correct rpm ?

I will need some help with this please.