### PR TITLE
Install server from rpm to the latest working version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,12 @@ postgres_config_file_contents: ''
 # Internal role variables, do not modify
 ######################################################################
 
+version_sub_version:
+  "14": "19"
+  "15": "14"
+  "16": "10"
+  "17": "6"
+  "18": "0"
 # Attributes are parsed and used to set facts at tasks/redhat.yml.
 # Overriding the default values allow to configure future versions of
 # PostgreSQL, e.g. different paths according to the version, config, etc.

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,20 +1,34 @@
 ---
 # tasks file for ome.postgresql rocky
 
+#- name: postgres | install server packages
+#  become: true
+#  ansible.builtin.dnf:
+#    name: >-
+#      {{ postgresql_dist_redhat.basename }}-server{{
+#         postgresql_dist_redhat.version_suffix }}
+#    state: present
+
+#- name: postgres | install extension packages
+#  become: true
+#  ansible.builtin.dnf:
+#    name: >-
+#      {{ postgresql_dist_redhat.basename }}-contrib{{
+#         postgresql_dist_redhat.version_suffix }}
+#    state: present
+
 - name: postgres | install server packages
   become: true
   ansible.builtin.dnf:
-    name: >-
-      {{ postgresql_dist_redhat.basename }}-server{{
-         postgresql_dist_redhat.version_suffix }}
+    name: "https://download.postgresql.org/pub/repos/yum/{{ postgresql_version }}/redhat/rhel-9-x86_64/postgresql{{ postgresql_version }}-server-{{ postgresql_version }}.{{ version_sub_version[postgresql_version] }}-1PGDG.rhel9.x86_64.rpm"
     state: present
 
 - name: postgres | install extension packages
   become: true
   ansible.builtin.dnf:
-    name: >-
-      {{ postgresql_dist_redhat.basename }}-contrib{{
-         postgresql_dist_redhat.version_suffix }}
+    name:
+      "https://download.postgresql.org/pub/repos/yum/{{ postgresql_version }}/redhat/rhel-9-x86_64/{{ postgresql_dist_redhat.basename }}-contrib-{{ postgresql_version }}.{{ version_sub_version[postgresql_version] }}-1PGDG.rhel9.x86_64.rpm"
+
     state: present
 
 - name: postgres | install ansible prerequisites


### PR DESCRIPTION
This PR addresses and fixes the issue on https://github.com/ome/ansible-role-postgresql/pull/43.
It seems that the latest PostgreSQL build, released in November, requires OPENSSL_3.4.0, so all server releases from 14 to 18 have the same issue.  
Updating OPENSSL_3.4.0 is not recommended as it will break the system package dependencies. So, we should use the previous server sub-versions, which do not have the OpenSSL_3.4.0 issue. 
I changed the package installation to use rpm and added a new variable (`version_sub_version`) to achieve that, and commented out the current package installation, as we may need it later.
