### PR TITLE
Remove image_version tags

### DIFF
--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -12,7 +12,7 @@ lint: |
 platforms:
   - name: postgresql-14-r9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host
@@ -22,7 +22,7 @@ platforms:
       - extra_options
   - name: postgresql-15-r9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host
@@ -32,7 +32,7 @@ platforms:
       - extra_options
   - name: postgresql-16-r9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host
@@ -42,7 +42,7 @@ platforms:
       - extra_options
   - name: postgresql-17-r9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host
@@ -52,7 +52,7 @@ platforms:
       - extra_options
   - name: postgresql-18-r9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
In order to fix the failing build in GHA here, analogically to the already merged PRs in ansible-role-omero-web and ansible-role-omero-server (https://github.com/ome/ansible-role-omero-server/pull/93 and https://github.com/ome/ansible-role-omero-web/pull/59), the molecule 26 is not happy with the ``image_version`` tag in the yml file.


I will not merge this PR so as to leave time for @khaledk2 to have a look at the strategy.

Thank you